### PR TITLE
Merge HTML template with Godot 4.4 latest

### DIFF
--- a/addons/godot-aria/godot_aria_shell.html
+++ b/addons/godot-aria/godot_aria_shell.html
@@ -55,6 +55,20 @@ body {
 	margin: auto;
 }
 
+#status-splash.show-image--false {
+	display: none;
+}
+
+#status-splash.fullsize--true {
+	height: 100%;
+	width: 100%;
+	object-fit: contain;
+}
+
+#status-splash.use-filter--false {
+	image-rendering: pixelated;
+}
+
 #status-progress, #status-notice {
 	display: block;
 }
@@ -168,7 +182,7 @@ body {
 		<div id="global-live-region" aria-live="polite" aria-relevant="all" data-hidden="true"></div>
 		<!-- Status -->
 		<div id="status" inert>
-			<img id="status-splash" src="$GODOT_SPLASH" alt="" aria-hidden="true">
+			<img id="status-splash" class="$GODOT_SPLASH_CLASSES" src="$GODOT_SPLASH" alt="" aria-hidden="true">
 			<progress id="status-progress" data-hidden="true" max="100" aria-hidden="true"></progress>
 			<div id="status-notice" data-hidden="true" aria-live="assertive"></div>
 		</div>


### PR DESCRIPTION
This puts the godot-aria HTML template in sync with the latest Godot default HTML template for web export.

I'm unsure whether this is a breaking change to users running Godot versions < 4.4